### PR TITLE
Add tags option to create_note and update_note

### DIFF
--- a/utils/schemas.ts
+++ b/utils/schemas.ts
@@ -56,6 +56,7 @@ export const CreateNoteOptionsSchema = z.object({
     .optional()
     .describe("Comment permission"),
   permalink: z.string().optional().describe("Custom permalink"),
+  tags: z.array(z.string()).optional().describe("Note tags"),
 });
 
 export const UpdateNoteOptionsSchema = z.object({
@@ -77,4 +78,5 @@ export const UpdateNoteOptionsSchema = z.object({
     .optional()
     .describe("Write permission"),
   permalink: z.string().optional().describe("Custom permalink"),
+  tags: z.array(z.string()).optional().describe("Note tags"),
 });


### PR DESCRIPTION
## What

Adds a `tags` field (array of strings) to `CreateNoteOptionsSchema` and `UpdateNoteOptionsSchema`.

## Why

The HackMD REST API and `@hackmd/api` both support a note `tags` field on create and update (it's part of `NoteType`/`CreateNote`/`UpdateNote`). The note tools already forward the entire `payload`/`options` object straight to `client.createNote` / `client.updateNote`, so the only thing preventing MCP clients from setting structured tags is that the two zod schemas don't expose the field.

Without this, the only way to "tag" a note via MCP is inline body text, which the HackMD UI's tag search doesn't pick up.

## Change

Two lines — one per schema:

```ts
tags: z.array(z.string()).optional().describe("Note tags"),
```

## Verification

Built with `tsc` (no type errors). Ran the built server over stdio and confirmed `create_note`/`update_note` advertise `payload.tags`, then end-to-end against a real account: `update_note` with `payload.tags: ["resume","worklog"]` → `get_note` returns those tags with `tagsUpdatedAt` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)