### PR TITLE
Add parentFolderId option to create_note and update_note

### DIFF
--- a/utils/schemas.ts
+++ b/utils/schemas.ts
@@ -56,6 +56,10 @@ export const CreateNoteOptionsSchema = z.object({
     .optional()
     .describe("Comment permission"),
   permalink: z.string().optional().describe("Custom permalink"),
+  parentFolderId: z
+    .string()
+    .optional()
+    .describe("ID of the folder to place the note in"),
 });
 
 export const UpdateNoteOptionsSchema = z.object({
@@ -77,4 +81,8 @@ export const UpdateNoteOptionsSchema = z.object({
     .optional()
     .describe("Write permission"),
   permalink: z.string().optional().describe("Custom permalink"),
+  parentFolderId: z
+    .string()
+    .optional()
+    .describe("ID of the folder to move the note into"),
 });


### PR DESCRIPTION
## What

Adds an optional `parentFolderId` (string) field to `CreateNoteOptionsSchema` and `UpdateNoteOptionsSchema`.

## Why

The HackMD REST API and `@hackmd/api` v2.5.0 both accept `parentFolderId` on create and update (it's in `CreateNoteOptions` / `UpdateNoteOptions`). The note tools already forward the entire `payload`/`options` object to `client.createNote` / `client.updateNote`, so the only thing preventing MCP clients from placing a note in a folder is that the two zod schemas don't expose the field.

## Change

Two fields — one per schema:

```ts
parentFolderId: z.string().optional().describe("ID of the folder to place the note in"),
```

## Verification

Built with `tsc` (no type errors). Ran the built server over stdio and confirmed `create_note`/`update_note` advertise `payload.parentFolderId`, then end-to-end against a real account: `create_note` with `parentFolderId` files the new note into that folder and it appears there in the HackMD web UI.

Note: setting `parentFolderId` on **create** (POST) places the note in the folder and is reflected in the HackMD web UI. Setting it on **update** (PATCH) of an existing note updates the note's `folderPaths` metadata but, in my testing, the HackMD web UI's folder tree does not reflect the move — this appears to be a HackMD API/UI limitation (the UI tree is backed by an internal Yjs preferences structure the public API doesn't write), not something this change can address. Exposing the field on update is still useful for parity and metadata correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)