### PR TITLE
feat: expose tags and parentFolderId in note create/update schemas

### DIFF
--- a/utils/schemas.ts
+++ b/utils/schemas.ts
@@ -56,6 +56,11 @@ export const CreateNoteOptionsSchema = z.object({
     .optional()
     .describe("Comment permission"),
   permalink: z.string().optional().describe("Custom permalink"),
+  tags: z.array(z.string()).optional().describe("Note tags"),
+  parentFolderId: z
+    .string()
+    .optional()
+    .describe("Parent folder ID (places the note in that folder)"),
 });
 
 export const UpdateNoteOptionsSchema = z.object({
@@ -77,4 +82,10 @@ export const UpdateNoteOptionsSchema = z.object({
     .optional()
     .describe("Write permission"),
   permalink: z.string().optional().describe("Custom permalink"),
+  title: z.string().optional().describe("Note title"),
+  tags: z.array(z.string()).optional().describe("Note tags"),
+  parentFolderId: z
+    .string()
+    .optional()
+    .describe("Parent folder ID (moves the note to that folder)"),
 });


### PR DESCRIPTION
## What
The `@hackmd/api` SDK's `CreateNoteOptions` / `UpdateNoteOptions` already support `tags` and `parentFolderId`, and the tool handlers forward the payload to the SDK unchanged. But the zod schemas in `utils/schemas.ts` dropped these fields, so MCP clients can't:

- tag a note, or
- create / move a note into a specific folder.

## Change
Add `tags` and `parentFolderId` to `CreateNoteOptionsSchema` and `UpdateNoteOptionsSchema` (plus `title` to the update schema, which the SDK also supports). Schema-only change — no handler edits. Applies to `create_note`, `update_note`, `create_team_note`, `update_team_note` (shared schemas).

## Verification
`pnpm run build` (tsc) passes. The pinned `@hackmd/api ^2.5.0` already declares both fields in `type.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
